### PR TITLE
Amendment in Developer/Development

### DIFF
--- a/docs/docs-site/content/developer/development/_index.md
+++ b/docs/docs-site/content/developer/development/_index.md
@@ -27,6 +27,9 @@ Build once:
     # Mac user might need to set
     export SKIP_PYTHONDEV_CHECK=true
 
+    # export ROOT which should point to your Hue directory
+    export ROOT=<path_to_hue_directory>
+
     make apps
 
 The [dependencies documentation](/administrator/installation/dependencies/) is here to help for troubleshooting build issues.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Addition of below 2 lines under Build once section: #export ROOT which should point to your Hue directory
 export ROOT=<path_to_hue_directory>


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
