### PR TITLE
Update in administrator/installation/dependencies

### DIFF
--- a/docs/docs-site/content/administrator/installation/dependencies/_index.md
+++ b/docs/docs-site/content/administrator/installation/dependencies/_index.md
@@ -17,6 +17,9 @@ Versions supported:
 ```
 # If you are using Python 3.6+, set PYTHON_VER before the build, like
 export PYTHON_VER=python3.8
+
+# Export ROOT which should point to your Hue directory
+export ROOT=<path_to_hue_directory>
 ```
 
 ## Database


### PR DESCRIPTION
## What changes were proposed in this pull request?
Addition of below 2 lines in the document under Python section: # Export ROOT which should point to your Hue directory
 export ROOT=<path_to_hue_directory>

Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
